### PR TITLE
PyUtils broadcaster

### DIFF
--- a/astropop/_db.py
+++ b/astropop/_db.py
@@ -670,9 +670,9 @@ class SQLDatabase:
 
         dict_row_list = _dict2row(cols=self.column_names(table), **data)
         try:
-            rows = np.broadcast(**dict_row_list)
+            rows = np.broadcast(*dict_row_list)
         except ValueError:
-            rows = broadcast(**dict_row_list)
+            rows = broadcast(*dict_row_list)
         rows = list(zip(*rows.iters))
         self._add_data_list(table, rows)
 

--- a/astropop/_db.py
+++ b/astropop/_db.py
@@ -6,7 +6,7 @@ import numpy as np
 from astropy.table import Table
 
 from .logger import logger
-from .py_utils import check_iterable
+from .py_utils import check_iterable, broadcast
 
 
 __all__ = ['SQLDatabase', 'SQLTable', 'SQLRow', 'SQLColumn', 'SQLColumnMap']
@@ -668,7 +668,11 @@ class SQLDatabase:
         if add_columns:
             self._add_missing_columns(table, data.keys())
 
-        rows = np.broadcast(*_dict2row(cols=self.column_names(table), **data))
+        dict_row_list = _dict2row(cols=self.column_names(table), **data)
+        try:
+            rows = np.broadcast(**dict_row_list)
+        except ValueError:
+            rows = broadcast(**dict_row_list)
         rows = list(zip(*rows.iters))
         self._add_data_list(table, rows)
 

--- a/astropop/py_utils.py
+++ b/astropop/py_utils.py
@@ -145,9 +145,12 @@ class broadcast:
         self.index += 1
         return arr
 
+    @property
     def iters(self):
         """Return the tuple containing the iterators."""
-        return tuple(i for i in self)
+        return tuple(np.array(a) if self.is_array[i]
+                     else np.array([a]*self.length)
+                     for i, a in enumerate(self.args))
 
     def __len__(self):
         """Return the length of the broadcast."""

--- a/astropop/py_utils.py
+++ b/astropop/py_utils.py
@@ -98,7 +98,6 @@ def check_iterable(value):
     return False
 
 
-@np.vectorize
 def _get_length(value):
     """Get the length of iterable only values."""
     if not check_iterable(value):
@@ -115,7 +114,7 @@ class broadcast:
             raise ValueError("Empty broadcast")
 
         self.args = args
-        lengths = _get_length(args)
+        lengths = np.array([_get_length(a) for a in args])
         if np.all(lengths == -1):
             self.length = 0
         else:

--- a/astropop/py_utils.py
+++ b/astropop/py_utils.py
@@ -148,6 +148,8 @@ class broadcast:
     @property
     def iters(self):
         """Return the tuple containing the iterators."""
+        if self.length == 0:
+            return tuple([a] for a in self.args)
         return tuple(np.array(a) if self.is_array[i]
                      else np.array([a]*self.length)
                      for i, a in enumerate(self.args))

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -240,6 +240,16 @@ class Test_SQLDatabase_Creation_Modify:
         assert_equal(db.table_names, ['test'])
         assert_equal(db.column_names('test'), ['a', 'b', 'd'])
 
+    def test_sql_add_row_superpass_64_limit(self):
+        db = SQLDatabase(':memory:')
+        db.add_table('test')
+        db.add_rows('test', {f'col{i}': np.arange(10) for i in range(128)},
+                     add_columns=True)
+        assert_equal(db.column_names('test'), [f'col{i}' for i in range(128)])
+
+        for i, v in enumerate(db.select('test')):
+            assert_equal(v, [i]*128)
+
     def test_sqltable_add_column(self):
         db = SQLDatabase(':memory:')
         db.add_table('test')

--- a/tests/test_pyutils.py
+++ b/tests/test_pyutils.py
@@ -226,6 +226,15 @@ class Test_Broadcast():
         for i in range(10):
             assert_equal(next(it), [i]*64)
 
+    def test_broadcast_iters_only_scalars(self):
+        bc = broadcast(1, 2, 3)
+        assert_equal(bc.iters, [[1], [2], [3]])
+
+    def test_broadcast_iters(self):
+        bc = broadcast(np.arange(10), 3, 2)
+
+        assert_equal(bc.iters, [np.arange(10), [3]*10, [2]*10])
+
 class Test_IndexedDict():
     def test_indexeddict_create(self):
         d = dict(a=1, b=2, c=3)

--- a/tests/test_pyutils.py
+++ b/tests/test_pyutils.py
@@ -5,7 +5,8 @@ import pytest
 import shlex
 from astropop.py_utils import string_fix, process_list, \
                               check_iterable, batch_key_replace, \
-                              run_command, IndexedDict, check_number
+                              run_command, IndexedDict, check_number, \
+                              broadcast
 import numpy as np
 
 from astropop.testing import assert_true, assert_equal, assert_in, \
@@ -177,6 +178,53 @@ class Test_BatchKeyReplace():
         batch_key_replace(dic1)
         assert_equal(dic1['a'], "['61', '42'] value")
 
+
+class Test_Broadcast():
+    def test_broadcast(self):
+        a = np.arange(10)
+        b = np.arange(1, 11)
+        c = 2
+
+        bc = broadcast(a, b, c)
+        iterator = iter(bc)
+
+        indx = 0
+        for i in range(10):
+            assert_equal(next(iterator), [a[indx], b[indx], c])
+            indx += 1
+
+        with pytest.raises(StopIteration):
+            next(iterator)
+
+    def test_broadcast_empty(self):
+        with pytest.raises(ValueError):
+            broadcast()
+
+    def test_broadcast_wrong_shape(self):
+        a = np.arange(10)
+        b = np.arange(5)
+
+        with pytest.raises(ValueError):
+            broadcast(a, b)
+
+    def test_broadcast_only_scalars(self):
+        a = 1
+        b = 2
+        c = 3
+
+        bc = broadcast(a, b, c)
+
+        for i in bc:
+            assert_equal(i, [a, b, c])
+
+    def test_broadcast_superpass_32_limit(self):
+        arr = [np.arange(10)]*64
+        bc = broadcast(*arr)
+        assert_equal(len(bc), 10)
+        it = iter(bc)
+
+        for i in range(10):
+            assert_equal(next(it), [i]*64)
 
 class Test_IndexedDict():
     def test_indexeddict_create(self):


### PR DESCRIPTION
`np.bradcast` has a limit of maximum 32 arguments. However, for fits headers, this may not be enough. So, we implemented a slower, but limitless alternative. `SQLDatabase` can use it to broadcating in add_rows, but will always prefer numpy version.