### PR TITLE
GaiaDR3 improve

### DIFF
--- a/astropop/catalogs/gaia.py
+++ b/astropop/catalogs/gaia.py
@@ -76,8 +76,9 @@ class GaiaDR3SourcesCatalog(_OnlineSourcesCatalog):
 
     def radial_velocity(self):
         """Return the radial velocity for the sources."""
-        return QFloat(self._query['radial_velocity'],
-                      self._query['radial_velocity_error'],
+        return QFloat(np.array(self._query['radial_velocity'], dtype='f4'),
+                      np.array(self._query['radial_velocity_error'],
+                               dtype='f4'),
                       unit='km/s')
 
     def phot_variable_flag(self):

--- a/astropop/catalogs/gaia.py
+++ b/astropop/catalogs/gaia.py
@@ -4,6 +4,7 @@
 import copy
 import numpy as np
 from astropy.coordinates import SkyCoord
+from astropy import units as u
 from astroquery.gaia import Gaia
 from astropy.time import Time
 
@@ -27,7 +28,7 @@ class GaiaDR3SourcesCatalog(_OnlineSourcesCatalog):
         If center is a string, can be an object name or the string
         containing the object coordinates. If it is a tuple, have to be
         (ra, dec) coordinates, in hexa or decimal degrees format.
-    radius: string, float, `~astropy.coordinates.Angle` (optional)
+    radius: string, float, `~astropy.coordinates.Angle`
         The radius to search. If None, the query will be performed as
         single object query mode. Else, the query will be performed as
         field mode. If a string value is passed, it must be readable by
@@ -38,6 +39,9 @@ class GaiaDR3SourcesCatalog(_OnlineSourcesCatalog):
         informations will be disabled. If ``'all'`` (default), all
         available filters will be queried. If a list, all filters in that
         list will be queried. By default, all filters are available.
+    max_g_mag: float (optional)
+        Maximum G-band magnitude to query. If None, no magnitude
+        filtering will be performed. Default is None.
 
     Raises
     ------
@@ -49,12 +53,44 @@ class GaiaDR3SourcesCatalog(_OnlineSourcesCatalog):
     _columns = ['DESIGNATION', 'ref_epoch', 'ra', 'dec', 'pmra', 'pmdec',
                 'phot_g_mean_mag', 'phot_bp_mean_mag', 'phot_rp_mean_mag',
                 'phot_g_mean_flux_over_error', 'phot_bp_mean_flux_over_error',
-                'phot_rp_mean_flux_over_error']
+                'phot_rp_mean_flux_over_error', 'parallax', 'parallax_error',
+                'radial_velocity', 'radial_velocity_error',
+                'phot_variable_flag', 'non_single_star',
+                'in_galaxy_candidates']
+
+    def __init__(self, center, radius, band='all', max_g_mag=None):
+        self._setup_catalog()
+        self._max_g_mag = max_g_mag
+        _OnlineSourcesCatalog.__init__(self, center, radius=radius, band=band)
 
     def _setup_catalog(self):
         self._g = copy.deepcopy(Gaia)
         self._g.MAIN_GAIA_TABLE = 'gaiadr3.gaia_source'
         self._g.ROW_LIMIT = -1
+
+    def parallax(self):
+        """Return the parallax for the sources."""
+        return QFloat(self._query['parallax'],
+                      self._query['parallax_error'],
+                      unit='mas')
+
+    def radial_velocity(self):
+        """Return the radial velocity for the sources."""
+        return QFloat(self._query['radial_velocity'],
+                      self._query['radial_velocity_error'],
+                      unit='km/s')
+
+    def phot_variable_flag(self):
+        """Return the photometric variable flag for the sources."""
+        return np.array(self._query['phot_variable_flag'], dtype=bool)
+
+    def non_single_star(self):
+        """Return if each source is the non single star table."""
+        return np.array(self._query['non_single_star'], dtype=bool)
+
+    def in_galaxy_candidates(self):
+        """Return if the source is in galaxy candidates table."""
+        return np.array(self._query['in_galaxy_candidates'], dtype=bool)
 
     @staticmethod
     def _filter_magnitudes(query, band):
@@ -66,10 +102,46 @@ class GaiaDR3SourcesCatalog(_OnlineSourcesCatalog):
         mag_err = 1.1/np.array(query[f'phot_{f}_mean_flux_over_error'])
         return QFloat(mag, mag_err, unit='mag')
 
+    def _query_object_async(self, center, radius=None, columns=None):
+        """Construct the query and launch job. Good for max_g_mag filtering."""
+        # Based on astroquery.gaia.Gaia.query_object_async
+        columns = ','.join(map(str, columns))
+
+        ra = center.ra.degree
+        dec = center.dec.degree
+
+        if self._max_g_mag is not None:
+            mag_filtering = f'AND phot_g_mean_mag < {self._max_g_mag}'
+        else:
+            mag_filtering = ''
+
+        query = f"""
+            SELECT
+                {columns},
+                DISTANCE(
+                    POINT('ICRS', {self._g.MAIN_GAIA_TABLE_RA},
+                                  {self._g.MAIN_GAIA_TABLE_DEC}),
+                    POINT('ICRS', {ra}, {dec})
+                ) AS dist
+                FROM
+                  {self._g.MAIN_GAIA_TABLE}
+                WHERE
+                  1 = CONTAINS(POINT( 'ICRS', {self._g.MAIN_GAIA_TABLE_RA},
+                                              {self._g.MAIN_GAIA_TABLE_DEC}),
+                      CIRCLE('ICRS', {ra}, {dec}, {radius})
+                  )
+                  {mag_filtering}
+                ORDER BY
+                  dist ASC
+        """
+
+        return self._g.launch_job_async(query,
+                                        dump_to_file=False).get_results()
+
     def _do_query(self):
-        self._query = astroquery_query(self._g.query_object_async,
+        self._query = astroquery_query(self._query_object_async,
                                        self._center,
-                                       radius=self._radius,
+                                       radius=self._radius.to(u.deg).value,
                                        columns=self._columns)
         sk = SkyCoord(self._query['ra'], self._query['dec'],
                       obstime=Time(self._query['ref_epoch'], format='jyear'))

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,1 @@
-comment:
-  layout: "reach,diff,flags,files,footer"
-  behavior: new
-  require_changes: no
+comment: false

--- a/docs/tools/catalog/gaia.rst
+++ b/docs/tools/catalog/gaia.rst
@@ -37,7 +37,7 @@ Gaia catalogs can be huge. So, additionally, the initialization of the |GaiaDR3S
 
 .. ipython:: python
 
-    gaia_sources = gaia.gaiadr3('Sirius', radius='60 arcsec', max_g_mag=10)
+    gaia_sources = gaia.gaiadr3('HD 5020', radius='60 arcsec', max_g_mag=10)
     gaia_sources.table()
 
 Additional Catalog Properties

--- a/docs/tools/catalog/gaia.rst
+++ b/docs/tools/catalog/gaia.rst
@@ -71,11 +71,11 @@ Also, important variability and non-punctual flags are available as properties:
 
     gaia_sources.non_single_star()
 
-.. automethod:: astropop.catalogs.gaia.GaiaDR3SourcesCatalog.in_galaxy_canditates
+.. automethod:: astropop.catalogs.gaia.GaiaDR3SourcesCatalog.in_galaxy_candidates
 
 .. ipython:: python
 
-    gaia_sources.in_galaxy_canditates()
+    gaia_sources.in_galaxy_candidates()
 
 
 .. automodapi:: astropop.catalogs.gaia

--- a/docs/tools/catalog/gaia.rst
+++ b/docs/tools/catalog/gaia.rst
@@ -47,15 +47,35 @@ The |GaiaDR3SourcesCatalog| class has some additional properties. You can get pa
 
 .. automethod:: astropop.catalogs.gaia.GaiaDR3SourcesCatalog.parallax
 
+.. ipython:: python
+
+    gaia_sources.parallax()
+
 .. automethod:: astropop.catalogs.gaia.GaiaDR3SourcesCatalog.radial_velocity
+
+.. ipython:: python
+
+    gaia_sources.radial_velocity()
 
 Also, important variability and non-punctual flags are available as properties:
 
 .. automethod:: astropop.catalogs.gaia.GaiaDR3SourcesCatalog.phot_variable_flag
 
+.. ipython:: python
+
+    gaia_sources.phot_variable_flag()
+
 .. automethod:: astropop.catalogs.gaia.GaiaDR3SourcesCatalog.non_single_star
 
+.. ipython:: python
+
+    gaia_sources.non_single_star()
+
 .. automethod:: astropop.catalogs.gaia.GaiaDR3SourcesCatalog.in_galaxy_canditates
+
+.. ipython:: python
+
+    gaia_sources.in_galaxy_canditates()
 
 
 .. automodapi:: astropop.catalogs.gaia

--- a/docs/tools/catalog/gaia.rst
+++ b/docs/tools/catalog/gaia.rst
@@ -30,6 +30,33 @@ All the 3 Gaia filters are available for photometry: ``G``, ``BP`` and ``RP``. A
 
     \sigma_{mag} \approx \frac{1.1}{SNR_{flux}}
 
+Limiting Magnitude and Number of Sources
+----------------------------------------
+
+Gaia catalogs can be huge. So, additionally, the initialization of the |GaiaDR3SourcesCatalog| class accepts a parameter to perform maximum G magnitude for the query called ``max_g_mag``. This parameter is useful to limit the number of sources returned by the query. For example, if we want to query the Gaia DR3 catalog for the ``Sirius`` star, but only for sources with G magnitude less than 10, we can do:
+
+.. ipython:: python
+
+    gaia_sources = gaia.gaiadr3('Sirius', radius='60 arcsec', max_g_mag=10)
+    gaia_sources.table()
+
+Additional Catalog Properties
+-----------------------------
+
+The |GaiaDR3SourcesCatalog| class has some additional properties. You can get parallax and radial velocities from the catalog using the ``parallax`` and ``radial_velocity`` properties.
+
+.. automethod:: astropop.catalogs.gaia.GaiaDR3SourcesCatalog.parallax
+
+.. automethod:: astropop.catalogs.gaia.GaiaDR3SourcesCatalog.radial_velocity
+
+Also, important variability and non-punctual flags are available as properties:
+
+.. automethod:: astropop.catalogs.gaia.GaiaDR3SourcesCatalog.phot_variable_flag
+
+.. automethod:: astropop.catalogs.gaia.GaiaDR3SourcesCatalog.non_single_star
+
+.. automethod:: astropop.catalogs.gaia.GaiaDR3SourcesCatalog.in_galaxy_canditates
+
 
 .. automodapi:: astropop.catalogs.gaia
     :no-inheritance-diagram:

--- a/tests/test_catalogs_online.py
+++ b/tests/test_catalogs_online.py
@@ -1039,9 +1039,23 @@ class Test_Vizier_GaiaDR3:
         assert_equal(s.ra_dec_list().shape, (len(s), 2))
         assert_is_instance(s.mag_list('G'), np.ndarray)
         assert_equal(s.mag_list('G').shape, (len(s), 2))
+        # properties only for gaia
+        assert_is_instance(s.parallax(), QFloat)
+        assert_is_instance(s.radial_velocity(), QFloat)
+        # flags
+        assert_is_instance(s.non_single_star(), np.ndarray)
+        assert_equal(s.non_single_star().shape, (len(s),))
+        assert_equal(s.non_single_star().dtype, bool)
+        assert_is_instance(s.phot_variable_flag(), np.ndarray)
+        assert_equal(s.phot_variable_flag().shape, (len(s),))
+        assert_equal(s.phot_variable_flag().dtype, bool)
+        assert_is_instance(s.in_galaxy_candidates(), np.ndarray)
+        assert_equal(s.in_galaxy_candidates().shape, (len(s),))
+        assert_equal(s.in_galaxy_candidates().dtype, bool)
 
     def test_gaiadr3_properties(self):
-        s = GaiaDR3SourcesCatalog(hd674_coords[0], search_radius[0], band=['G'])
+        s = GaiaDR3SourcesCatalog(hd674_coords[0], search_radius[0],
+                                  band=['G'])
         assert_equal(s.available_filters,
                      ['G', 'BP', 'RP'])
         assert_is_instance(s.center, SkyCoord)
@@ -1053,3 +1067,10 @@ class Test_Vizier_GaiaDR3:
         # when using non-async functions, the output is limited to 2000 sources
         g = GaiaDR3SourcesCatalog('RMC 40', radius='15 arcmin')
         assert_greater(len(g), 2001)
+
+    def test_gaiadr3_max_mag(self):
+        s = GaiaDR3SourcesCatalog(hd674_coords[0], '1.0 deg',
+                                  band=['G'], max_g_mag=15)
+        # GAIA DR3 has only 741 sources brighter than 15 mag in this radius
+        assert_less(len(s), 1000)
+        assert_false(np.any(s.magnitude('G').nominal > 15))

--- a/tests/test_catalogs_online.py
+++ b/tests/test_catalogs_online.py
@@ -1000,7 +1000,7 @@ class Test_Tycho2VizierSourcesCatalog:
 
 
 @pytest.mark.remote_data
-class Test_Vizier_GaiaDR3:
+class Test_GaiaDR3:
     hd674_mags = {
         'G': [10.552819, 0.000337826],
         'BP': [10.649535, 0.00091911],


### PR DESCRIPTION
Now GaiaDR queries have new resources:
- Parallax, radial velocity and distance exposed. fix #97 
- Variability flags: `phot_variable_flag`, `non_single_star` and `in_galaxy_candidates` fix #96 
- Filter query by maximum G magnitude with `max_g_mag` argument in initialization. fix #98 