### PR TITLE
Header double keyword

### DIFF
--- a/astropop/framedata/_compat.py
+++ b/astropop/framedata/_compat.py
@@ -127,7 +127,7 @@ def _normalize_and_strip_dict(meta):
 
         if k in nmeta:
             # as dicts are case sensitive, this can happen. Raise error
-            raise UserWarning(f'Duplicated key {k}. First value will be used.')
+            warnings.warn(f'Duplicated key {k}. First value will be used.')
         if k not in _PROCTECTED and k != '' and k not in nmeta:
             # remove protected keys
             nmeta[k] = v

--- a/astropop/framedata/_compat.py
+++ b/astropop/framedata/_compat.py
@@ -127,9 +127,8 @@ def _normalize_and_strip_dict(meta):
 
         if k in nmeta:
             # as dicts are case sensitive, this can happen. Raise error
-            raise KeyError(f'Duplicated key {k}. Only dictionaries with '
-                           'unique keys are allowed.')
-        if k not in _PROCTECTED and k != '':
+            raise Warning(f'Duplicated key {k}. First value will be used.')
+        if k not in _PROCTECTED and k != '' and k not in nmeta:
             # remove protected keys
             nmeta[k] = v
 

--- a/astropop/framedata/_compat.py
+++ b/astropop/framedata/_compat.py
@@ -127,7 +127,7 @@ def _normalize_and_strip_dict(meta):
 
         if k in nmeta:
             # as dicts are case sensitive, this can happen. Raise error
-            raise Warning(f'Duplicated key {k}. First value will be used.')
+            raise UserWarning(f'Duplicated key {k}. First value will be used.')
         if k not in _PROCTECTED and k != '' and k not in nmeta:
             # remove protected keys
             nmeta[k] = v

--- a/tests/test_framedata_compat.py
+++ b/tests/test_framedata_compat.py
@@ -4,7 +4,8 @@
 import pytest
 import numpy as np
 from astropop.framedata._compat import extract_header_wcs, _extract_ccddata, \
-                                      _extract_fits, _merge_and_clean_header
+                                      _extract_fits, _merge_and_clean_header, \
+                                      _normalize_and_strip_dict
 from astropy.io import fits
 from astropy.wcs import WCS
 from astropy.table import Table
@@ -122,6 +123,16 @@ COMMENT This is a first comment
 COMMENT This is a second comment
 COMMENT This is a third comment
 """
+
+
+class Test_NormalizeAndStripHeader():
+    def test_double_keyword_warning(self):
+        header = _base_header
+        header += "TEST    =           0.10000000 / Test multiple keywords\n"
+        header += "Test    =           0.20000000 / Test multiple keywords\n"
+        h = fits.Header.fromstring(header, sep='\n')
+        with pytest.warns(UserWarning) as record:
+            h = _normalize_and_strip_dict(h)
 
 
 class Test_MergeAndCleanHeader():


### PR DESCRIPTION
Astropy accept duplicated keyword in a header. So raise warnings and not errors in this case.