### PR TITLE
framedata: to_hdu fix for None history or comment

### DIFF
--- a/astropop/framedata/_compat.py
+++ b/astropop/framedata/_compat.py
@@ -310,10 +310,12 @@ def _to_hdu(frame, hdu_uncertainty=_HDU_UNCERT, hdu_flags=_HDU_FLAGS,
         unit_string = u.format.Fits.to_string(frame.unit)
     header[unit_key] = unit_string
 
-    for i in frame.history:
-        header['history'] = i
-    for i in frame.comment:
-        header['comment'] = i
+    if frame.history is not None:
+        for i in frame.history:
+            header['history'] = i
+    if frame.comment is not None:
+        for i in frame.comment:
+            header['comment'] = i
     hdul = fits.HDUList(fits.PrimaryHDU(data, header=header))
 
     if hdu_uncertainty and frame._unct is not None:

--- a/astropop/framedata/framedata.py
+++ b/astropop/framedata/framedata.py
@@ -339,6 +339,8 @@ class FrameData:
 
     @history.setter
     def history(self, value):
+        if value is None:
+            return
         if not np.isscalar(value):
             self._history = self._history + list(value)
         else:
@@ -351,6 +353,8 @@ class FrameData:
 
     @comment.setter
     def comment(self, value):
+        if value is None:
+            return
         if not np.isscalar(value):
             self._comments = self._comments + list(value)
         else:

--- a/tests/test_framedata.py
+++ b/tests/test_framedata.py
@@ -198,6 +198,26 @@ class TestFrameDataCreationMetas:
         assert_not_in('history', frame.meta)
         assert_equal(frame.history, ['testing history'])
 
+    def test_framedata_no_history(self):
+        frame = FrameData([[1]])
+        assert_is_instance(frame.history, list)
+        assert_equal(frame.history, [])
+
+    def test_framedata_no_history_meta(self):
+        frame = FrameData([[1]], meta={'test': 'testing no history'})
+        assert_is_instance(frame.history, list)
+        assert_equal(frame.history, [])
+
+    def test_framedata_no_comment(self):
+        frame = FrameData([[1]])
+        assert_is_instance(frame.comment, list)
+        assert_equal(frame.comment, [])
+
+    def test_framedata_no_comment_meta(self):
+        frame = FrameData([[1]], meta={'test': 'testing no comment'})
+        assert_is_instance(frame.comment, list)
+        assert_equal(frame.comment, [])
+
 
 class TestFrameDataCreationData:
     def test_framedata_empty(self):

--- a/tests/test_framedata_io.py
+++ b/tests/test_framedata_io.py
@@ -69,6 +69,22 @@ class TestFrameData2FITS:
         assert_is_instance(hdul, fits.HDUList)
         assert_equal(hdul[0].header['comment'], ['test 1', 'test 2', 'test'])
 
+    def test_to_hdu_none_history(self):
+        frame = create_framedata()
+        frame._history = None
+
+        hdul = frame.to_hdu()
+        assert_is_instance(hdul, fits.HDUList)
+        assert_not_in('HISTORY', hdul[0].header)
+
+    def test_to_hdu_none_comment(self):
+        frame = create_framedata()
+        frame._comment = None
+
+        hdul = frame.to_hdu()
+        assert_is_instance(hdul, fits.HDUList)
+        assert_not_in('COMMENT', hdul[0].header)
+
     def test_write_unit_to_hdu(self):
         frame = create_framedata()
         ccd_unit = frame.unit

--- a/tests/test_framedata_meta.py
+++ b/tests/test_framedata_meta.py
@@ -6,34 +6,60 @@ from .test_framedata import create_framedata
 
 
 class Test_FrameData_History:
-    def test_framedata_set_history(self):
-        frame = create_framedata()
-        frame.history = 'once upon a time'
-        frame.history = 'a small fits file'
-        frame.history = ['got read', 'by astropop']
-        frame.history = ('and stay in', 'computer memory.')
+    hist = ['once upon a time', 'a small fits file',
+            'got read', 'by astropop',
+            'and stay in', 'computer memory.']
 
+    def test_framedata_set_history_string(self):
+        frame = create_framedata()
+        for i in self.hist:
+            frame.history = i
         assert_equal(len(frame.history), 6)
-        assert_equal(frame.history[0], 'once upon a time')
-        assert_equal(frame.history[1], 'a small fits file')
-        assert_equal(frame.history[2], 'got read')
-        assert_equal(frame.history[3], 'by astropop')
-        assert_equal(frame.history[4], 'and stay in')
-        assert_equal(frame.history[5],  'computer memory.')
+        assert_equal(frame.history, self.hist)
+
+    def test_framedata_set_history_none(self):
+        frame = create_framedata()
+        frame.history = None
+        assert_equal(frame.history, [])
+
+    def test_framedata_set_history_list(self):
+        frame = create_framedata()
+        frame.history = list(self.hist)
+        assert_equal(len(frame.history), 6)
+        assert_equal(frame.history, self.hist)
+
+    def test_framedata_set_history_tuple(self):
+        frame = create_framedata()
+        frame.history = tuple(self.hist)
+        assert_equal(len(frame.history), 6)
+        assert_equal(frame.history, self.hist)
 
 
 class Test_FrameData_Comment:
-    def test_framedata_set_comment(self):
+    comm = ['this is a test', 'to make commenst in astropop', 'that can',
+            'be lists', 'or also', 'tuples.']
+
+    def test_framedata_set_comment_string(self):
         frame = create_framedata()
-        frame.comment = 'this is a test'
-        frame.comment = 'to make commenst in astropop'
-        frame.comment = ['that can', 'be lists']
-        frame.comment = ('or also', 'tuples.')
+        for i in self.comm:
+            frame.comment = i
 
         assert_equal(len(frame.comment), 6)
-        assert_equal(frame.comment[0], 'this is a test')
-        assert_equal(frame.comment[1], 'to make commenst in astropop')
-        assert_equal(frame.comment[2], 'that can')
-        assert_equal(frame.comment[3], 'be lists')
-        assert_equal(frame.comment[4], 'or also')
-        assert_equal(frame.comment[5],  'tuples.')
+        assert_equal(frame.comment, self.comm)
+
+    def test_frame_set_comment_none(self):
+        frame = create_framedata()
+        frame.comment = None
+        assert_equal(frame.comment, [])
+
+    def test_frame_set_comment_list(self):
+        frame = create_framedata()
+        frame.comment = list(self.comm)
+        assert_equal(len(frame.comment), 6)
+        assert_equal(frame.comment, self.comm)
+
+    def test_frame_set_comment_tuple(self):
+        frame = create_framedata()
+        frame.comment = tuple(self.comm)
+        assert_equal(len(frame.comment), 6)
+        assert_equal(frame.comment, self.comm)


### PR DESCRIPTION
As reported by @FisiCarol , when FrameData have no history or comment set, to_hdu method fails. Now it should be safer.