### PR TITLE
Improve Cache Management

### DIFF
--- a/astropop/framedata/cache_manager.py
+++ b/astropop/framedata/cache_manager.py
@@ -4,7 +4,8 @@
 import os
 import atexit
 import shutil
-from platformdirs import user_cache_dir
+
+from astropy.config import get_cache_dir
 
 
 from ..logger import logger
@@ -18,7 +19,7 @@ __all__ = ['TempFile', 'TempDir', 'BaseTempDir', 'cleanup',
 # elements are TempDir instances
 managed_folders = []
 DELETE_ON_EXIT = True
-CACHE_DIR = os.path.join(user_cache_dir('astropop'))
+CACHE_DIR = os.path.join(get_cache_dir(), 'astropop')
 
 
 def cleanup():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,7 @@ dependencies = [
     "astroalign",
     "tqdm",
     "nest-asyncio",
-    "dbastable",
-    "platformdirs"
+    "dbastable"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Avoid the usage of `platformdirs` in favor of `astropy` default cache dir and let astropy handle that.