### PR TITLE
Photometry V3: Back do SEP

### DIFF
--- a/astropop/photometry/._sep.py
+++ b/astropop/photometry/._sep.py
@@ -1,0 +1,14 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Wrapper for SEP import, handling the multiple possible forks."""
+
+
+try:
+    import sep_pjw as sep
+except ImportError:
+    try:
+        import sep
+    except ImportError:
+        raise ImportError('SEP not found. Please install it.')
+
+
+__all__ = ['sep']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ dependencies = [
     "astroalign",
     "tqdm",
     "nest-asyncio",
-    "dbastable"
+    "dbastable",
+    "sep_pjw"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`photutils` photometry is causing several problems running the code. Specially, it is leading to a very slow reduction photometry.

The original version of `sep` is not receiving updates anymore. This was the main reason to change to `photutils`. However, new `sep` forks like `sep-pjw` are getting updated, lets use them.