### PR TITLE
Photutils v2.0 compatibility

### DIFF
--- a/astropop/photometry/detection.py
+++ b/astropop/photometry/detection.py
@@ -278,7 +278,7 @@ def daofind(data, threshold, background, noise, fwhm,
     # DaoStarFinder uses absolute threshold value
     thresh = np.median(threshold * noise)
 
-    dao = DAOStarFinder(thresh, fwhm=fwhm, sky=0,
+    dao = DAOStarFinder(thresh, fwhm=fwhm,
                         sharplo=sharplo, sharphi=sharphi,
                         roundlo=roundlo, roundhi=roundhi,
                         exclude_border=exclude_border,


### PR DESCRIPTION
With photutils 2.0, the argument sky on daofind has beend deprecated. Removed it.